### PR TITLE
Fixes integer division bug in calculating deviation

### DIFF
--- a/app/controllers/candidate_match.py
+++ b/app/controllers/candidate_match.py
@@ -77,7 +77,7 @@ class CandidateMatcher():
 
         for candidate in deviation.keys():
             try:
-                deviation[candidate]["percentage"] = deviation[candidate]["act_difference"] / deviation[candidate]["max_deviation"] * 100
+                deviation[candidate]["percentage"] = deviation[candidate]["act_difference"] * 100.0 / deviation[candidate]["max_deviation"]
             except ZeroDivisionError: # This happens when the user answers zero questions
                 deviation[candidate]["percentage"] = 100.0
 


### PR DESCRIPTION
There is a tiny but serious bug that needs attention.

When you calculate deviation percentage, if both `deviation[candidate]["act_difference"]` and  `deviation[candidate]["max_deviation"]` are integers, you will incorrectly compute the percentage to be 0. This is because in python integer division ignores the remainder, so say 1/2 results into 0. Since not all candidate answers are floats, this can easily happen. 

A very common bug, but a very serious one. Luckily, its also a very quick fix. I'd actually suggest standardizing all candidate answers to floats as a better way of fixing this issue but this method works just as well.
